### PR TITLE
Updated Driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,28 @@
-*.swp
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@ ntpd\_driver
 This ROS node listen `sensor_msgs/TimeReference` and send it to ntpd via SHM (like gpsd).
 
 Parameter `~/shm_unit` define SHM unit (in ntp.conf) (int, default: 2).
-
-Subscribe to topic `~/time_ref`.
-
-
+Parameter `~/time_ref` define the topic to subscribe to (string, default: "~/time_ref").
 
 System configuration
 --------------------
@@ -24,7 +21,7 @@ And then restart ntp service.
 
 Run example:
 
-    rosrun ntpd_driver shm_driver _shm_unit:=2 /ntpd_shm/time_ref:=/mavros/time_reference
+    rosrun ntpd_driver shm_driver _shm_unit:=2 _time_ref:=/mavros/time_reference
 
 ### chrony configuration
 
@@ -37,5 +34,5 @@ And then restart chrony service.
 
 Run example:
 
-    rosrun ntpd_driver shm_driver _shm_unit:=0 /ntpd_shm/time_ref:=/mavros/time_reference
+    rosrun ntpd_driver shm_driver _shm_unit:=0 _time_ref:=/mavros/time_reference
 

--- a/src/shm_driver.cpp
+++ b/src/shm_driver.cpp
@@ -10,7 +10,6 @@
  * Based on ntpshm.c from gpsd. 
  */
 
-
 #include <ros/ros.h>
 #include <ros/console.h>
 
@@ -77,8 +76,7 @@ static volatile struct shmTime *get_shmTime(int unit)
 		return NULL;
 	}
 
-	ROS_INFO("SHM(%d) key 0x%08lx, successfully opened",
-			unit, NTPD_SHM_BASE + unit);
+	ROS_INFO("SHM(%d) key 0x%08lx, successfully opened", unit, NTPD_SHM_BASE + unit);
 	return (volatile struct shmTime*) p;
 }
 
@@ -130,9 +128,9 @@ static void time_ref_cb(const sensor_msgs::TimeReference::ConstPtr &time_ref)
 	g_shm->count += 1;
 	g_shm->valid = 1;
 
-	ROS_DEBUG_THROTTLE(10, "Got time_ref: %lu.%09lu",
-			(long unsigned) time_ref->time_ref.sec,
-			(long unsigned) time_ref->time_ref.nsec);
+	ROS_DEBUG_THROTTLE(10, "Got time_ref: %lu.%09lu", 
+	    (long unsigned) time_ref->time_ref.sec, 
+	    (long unsigned) time_ref->time_ref.nsec);
 }
 
 int main(int argc, char *argv[])
@@ -150,10 +148,7 @@ int main(int argc, char *argv[])
 	if (g_shm == NULL)
 		return 1;
 
-	time_ref_sub = nh.subscribe("time_ref", 10, time_ref_cb,
-			ros::TransportHints()
-				.unreliable()
-				.maxDatagramSize(1024));
+	time_ref_sub = nh.subscribe("time_ref", 10, time_ref_cb);
 
 	ros::spin();
 	put_shmTime(&g_shm);


### PR DESCRIPTION
Hello there, we are using the `ntpd_driver` in one of our AUVs here in Heriot-Watt University and we did some changes in the driver that we would like to share back with the community. 

The main changes are:
- removal of the transport hints to allow this driver to work with the `nmea_serial_driver`, this is because the driver uses python and the UDP compatibility among roscpp and rospy is not guaranteed 
- fixed indentation according to the ROS guidelines
- added the time_ref node parameter to avoid remapping the input topic (this has been done without changing the original behaviour of the node)

The code has been tested with Ubuntu 14.04.02 LTS (both x86 and x86-64). Hope this can help others to adopt the use of this nice driver to keep the bot's properly in sync.
